### PR TITLE
Update app versions

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -57,7 +57,7 @@ ram.runtime = "50M"
         format = "tar.gz"
 
         [resources.sources.lts]
-        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_24.x_Wolf_359/24.0/tiki-24.3.tar.gz/download"
+        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_24.x_Wolf_359/24.3/tiki-24.3.tar.gz/download"
         sha256 = "b1e0468ece35376c4d641227cb25c17347751d191627d03652a75f64ebe3d877"
         format = "tar.gz"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -57,8 +57,8 @@ ram.runtime = "50M"
         format = "tar.gz"
 
         [resources.sources.lts]
-        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_24.x_Wolf_359/24.0/tiki-24.0.tar.gz/download"
-        sha256 = "2f9fd0e3509cf28c884173bfa58ff3aaa2e694f8c6051b0a94ba1bdbb243463e"
+        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_24.x_Wolf_359/24.0/tiki-24.3.tar.gz/download"
+        sha256 = "b1e0468ece35376c4d641227cb25c17347751d191627d03652a75f64ebe3d877"
         format = "tar.gz"
 
     [resources.system_user]

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Tiki"
 description.en = "Wiki-based, content management system"
 description.fr = "Système de gestion de contenu basé sur Wiki"
 
-version = "25.0~ynh1"
+version = "25.1~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -52,8 +52,8 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_25.x_Sagittarius_A/25.0/tiki-25.0.tar.gz/download"
-        sha256 = "e056cdcfdcb03a8c4710db44e7f04e0f846eb7131a8f8aa130a3d8348e0161a4"
+        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_25.x_Sagittarius_A/25.0/tiki-25.1.tar.gz/download"
+        sha256 = "6c7af7d6f42d4b25e7640912cab3756d086bb17b81d78ba7ae6d6aca51d1dbe4"
         format = "tar.gz"
 
         [resources.sources.lts]

--- a/manifest.toml
+++ b/manifest.toml
@@ -52,7 +52,7 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_25.x_Sagittarius_A/25.0/tiki-25.1.tar.gz/download"
+        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_25.x_Sagittarius_A/25.1/tiki-25.1.tar.gz/download"
         sha256 = "6c7af7d6f42d4b25e7640912cab3756d086bb17b81d78ba7ae6d6aca51d1dbe4"
         format = "tar.gz"
 


### PR DESCRIPTION
## Problem

- The actual main source url points to the 25.0 release while we have a new tiki release(25.1)
- The actual LTS source url points to the 24.0 while we have a new LTS release(24.3)

This prevent new installations to get the updated tiki version and for the existed installed app to upgrade to the new releases.

## Solution

- Update the main and LTS source url to respectively points to 25.1 and 24.3 releases.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
