### PR TITLE
2023 06 06 default fgal dir

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -2,5 +2,5 @@
 
 To ease the install process and first access, Tiki saves your uploaded files (office documents, images, pdf, etc. attached to wiki pages, forum posts, tracker items, file galleries...) by default in its database. This works perfectly in most cases but it is not the recommended setup if you need to save many thousands of files or more.
 
-In that case, consider switching from "Store to database" to "Store to directory", which you will find in the Configuration Wizard. Please use the preset path directory: `/home/yunohost.app/tiki<…>`. You will be able to migrate your currently uploaded files from one to the other.
+In that case, consider switching from "Store to database" to "Store to directory", which you will find in the Configuration Wizard. Please use the preset path directory: `__DATA_DIR__`. You will be able to migrate your currently uploaded files from one to the other.
 

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -2,4 +2,5 @@
 
 To ease the install process and first access, Tiki saves your uploaded files (office documents, images, pdf, etc. attached to wiki pages, forum posts, tracker items, file galleries...) by default in its database. This works perfectly in most cases but it is not the recommended setup if you need to save many thousands of files or more.
 
-In that case, consider switching from "Store to database" to "Store to directory", which you will find in the Configuration Wizard. Please use this preset path directory: `/home/yunohost.app/$app`. You will be able to migrate your currently uploaded files from one to the other.
+In that case, consider switching from "Store to database" to "Store to directory", which you will find in the Configuration Wizard. Please use the preset path directory: `/home/yunohost.app/tiki<…>`. You will be able to migrate your currently uploaded files from one to the other.
+

--- a/scripts/install
+++ b/scripts/install
@@ -72,10 +72,8 @@ exec_as_app console.php database:configure "$app" "$db_pwd" "$app"
 exec_as_app console.php database:install
 
 # Set default database directory
-FGALDIR=/home/yunohost.app/$app
 cd "$install_dir"
-sed -i -e "s#storage\/fgal#$FGALDIR#" lib/prefs/fgal.php
-
+sed -i -e "s#storage\/fgal#$data_dir#" lib/prefs/fgal.php
 # Lock installer
 exec_as_app console.php installer:lock
 

--- a/scripts/install
+++ b/scripts/install
@@ -71,6 +71,10 @@ exec_as_app console.php database:configure "$app" "$db_pwd" "$app"
 # Create database contents
 exec_as_app console.php database:install
 
+# Set default database directory
+FGALDIR=/home/yunohost.app/$app
+exec_as_app sed -i -e "s#storage\/fgal#$FGALDIR#" lib/prefs/fgal.php
+
 # Lock installer
 exec_as_app console.php installer:lock
 
@@ -78,7 +82,10 @@ exec_as_app console.php installer:lock
 exec_as_app console.php index:rebuild
 
 # Set on Long Term Support versions
-exec_as_app console.php preferences:set tiki_release_cycle longterm
+if [[ "$release_cycle" == "longterm" ]]
+then
+  exec_as_app console.php preferences:set tiki_release_cycle longterm
+fi
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -73,7 +73,7 @@ exec_as_app console.php database:install
 
 # Set default database directory
 cd "$install_dir"
-sed -i -e "s#storage\/fgal#$data_dir#" lib/prefs/fgal.php
+sed -i -e "s#storage/fgal#$data_dir#" lib/prefs/fgal.php
 # Lock installer
 exec_as_app console.php installer:lock
 

--- a/scripts/install
+++ b/scripts/install
@@ -73,6 +73,7 @@ exec_as_app console.php database:install
 
 # Set default database directory
 FGALDIR=/home/yunohost.app/$app
+cd "$install_dir"
 sed -i -e "s#storage\/fgal#$FGALDIR#" lib/prefs/fgal.php
 
 # Lock installer

--- a/scripts/install
+++ b/scripts/install
@@ -73,7 +73,7 @@ exec_as_app console.php database:install
 
 # Set default database directory
 FGALDIR=/home/yunohost.app/$app
-exec_as_app sed -i -e "s#storage\/fgal#$FGALDIR#" lib/prefs/fgal.php
+sed -i -e "s#storage\/fgal#$FGALDIR#" lib/prefs/fgal.php
 
 # Lock installer
 exec_as_app console.php installer:lock


### PR DESCRIPTION
## Problem

- The instructions for setting the files in ADMIN.md displayed « Please use the preset path directory: /home/yunohost.app/$app » instead of replacing $app with "Tiki" or "Tiki__1" etc. The proper value for $app changes when one installs more than one Tiki.

## Solution

- I patch the Tiki code so as to make the correct Yunohost path the default Tiki path.
- Users don't need to know and cut-paste the correct path any more.

## PR Status

- [ x] Code finished and ready to be reviewed/tested
- [ x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
