### PR TITLE
2023 06 16 fix upgrades

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -38,6 +38,12 @@ if [ -z "${fpm_usage:-}" ]; then
     ynh_app_setting_set --app=$app --key=fpm_usage --value=$fpm_usage
 fi
 
+# If release_cycle doesn't exist, create it
+if [ -z "${release_cycle:-}" ]; then
+    release_cycle=longterm
+    ynh_app_setting_set --app=$app --key=release_cycle --value=$release_cycle
+fi
+
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================


### PR DESCRIPTION
## Problem

- *Upgrading an old Tiki was failing with a « ./upgrade: line 51: release_cycle: unbound variable » message.*
- The Tiki was not upgraded.

## Solution

- *Add a "If release_cycle doesn't exist, create it" section in scripts/upgrade*. Thanks Aleks!

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
