### PR TITLE
Update app manifest resources sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Tiki Wiki CMS Groupware is the Free / Libre / Open Source Web Application with the most built-in features. Use cases: Web Publishing / Collaboration / Project Management / Office Suite / Knowledge base / Shopping Cart / Social Networking / CRM / Membership / E-learning. Tiki Trackers is the built-in database web apps builder and low-code / no-code application framework.
 
 
-**Shipped version:** 25.1~ynh2
+**Shipped version:** 25.2~ynh2
 
 **Demo:** https://tiki.org/Try-Tiki
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Tiki Wiki CMS Groupware est l'application Web libre dotée du plus grand nombre de fonctionnalités intégrées. Cas d'utilisation: Publication Web / Collaboration / Gestion de projet / Suite bureautique / Gestion des connaissances / Panier d'achat / Réseau social / Gestion de communauté et clientèle (CRM) / Membrariat / Système de gestion de l'apprentissage (LMS). Les Tiki Trackers sont la composante intégrée pour le développement low-code / no-code et le générateur de formulaires et bases de données.
 
 
-**Version incluse :** 25.1~ynh2
+**Version incluse :** 25.2~ynh2
 
 **Démo :** https://tiki.org/Try-Tiki
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Tiki"
 description.en = "Wiki-based, content management system"
 description.fr = "Système de gestion de contenu basé sur Wiki"
 
-version = "25.1~ynh2"
+version = "25.2~ynh2"
 
 maintainers = ["eric_G"]
 
@@ -52,13 +52,13 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_25.x_Sagittarius_A/25.1/tiki-25.1.tar.gz/download"
-        sha256 = "6c7af7d6f42d4b25e7640912cab3756d086bb17b81d78ba7ae6d6aca51d1dbe4"
+        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_25.x_Sagittarius_A/25.2/tiki-25.2.tar.gz/download"
+        sha256 = "312d71763e3dd1aa70ed1631a8cff000b4161e65b3caf5f524db4e600958c8ed"
         format = "tar.gz"
 
         [resources.sources.lts]
-        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_24.x_Wolf_359/24.3/tiki-24.3.tar.gz/download"
-        sha256 = "b1e0468ece35376c4d641227cb25c17347751d191627d03652a75f64ebe3d877"
+        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_24.x_Wolf_359/24.4/tiki-24.4.tar.gz/download"
+        sha256 = "1cb546e282ec74ce7bf6bbda96048b6b2b7087bb8416fd154eeb4b99d8e4f8c5"
         format = "tar.gz"
 
     [resources.system_user]


### PR DESCRIPTION
## Problem

- *Tiki has new important releases available (25.2 and 24.4) that need to be available for the tiki ynh app*

## Solution

- *Update the main and LTS source url to respectively points to 25.2 and 24.4 releases.*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
