### PR TITLE
Update the manifest.toml main resources sources to tiki-26.0 which supports php8.1 to php8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Tiki Wiki CMS Groupware is the Free / Libre / Open Source Web Application with t
 - Tiki Trackers is the built-in database web apps builder and low-code / no-code application framework.
 
 
-**Shipped version:** 25.2~ynh2
+**Shipped version:** 26.0~ynh2
 
 **Demo:** https://tiki.org/Try-Tiki
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -33,7 +33,7 @@ Tiki Wiki CMS Groupware est l'application Web libre dotée du plus grand nombre 
 Les Tiki Trackers sont la composante intégrée pour le développement low-code / no-code et le générateur de formulaires et bases de données.
 
 
-**Version incluse :** 25.2~ynh2
+**Version incluse :** 26.0~ynh2
 
 **Démo :** https://tiki.org/Try-Tiki
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Tiki"
 description.en = "Wiki-based, content management system"
 description.fr = "Système de gestion de contenu basé sur Wiki"
 
-version = "26.0~ynh2"
+version = "26.0~ynh1"
 
 maintainers = ["eric_G"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Tiki"
 description.en = "Wiki-based, content management system"
 description.fr = "Système de gestion de contenu basé sur Wiki"
 
-version = "25.2~ynh2"
+version = "26.0~ynh2"
 
 maintainers = ["eric_G"]
 
@@ -52,8 +52,8 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_25.x_Sagittarius_A/25.2/tiki-25.2.tar.gz/download"
-        sha256 = "312d71763e3dd1aa70ed1631a8cff000b4161e65b3caf5f524db4e600958c8ed"
+        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_26.x_Alnilam/26.0/tiki-26.0.tar.gz/download"
+        sha256 = "493f204407eefd102c2ed59e4e4e716ea1671e0d43d99dd8e4265a8e09f28335"
         format = "tar.gz"
 
         [resources.sources.lts]
@@ -71,7 +71,15 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "tesseract-ocr imagemagick mariadb-server php7.4-bz2 php7.4-curl php7.4-gd php7.4-zip php7.4-mysql php7.4-xml php7.4-mbstring"
+    packages = "tesseract-ocr imagemagick mariadb-server"
+
+    packages_from_raw_bash = """
+            if [[ "$release_cycle" == "regular" ]]; then 
+                echo "php8.1-bz2 php8.1-curl php8.1-gd php8.1-zip php8.1-mysql php8.1-xml php8.1-mbstring php8.1-intl"
+            else
+                echo "php7.4-bz2 php7.4-curl php7.4-gd php7.4-zip php7.4-mysql php7.4-xml php7.4-mbstring php7.4-intl"
+            fi
+        """
 
     [resources.database]
     type = "mysql"


### PR DESCRIPTION

## Problem

- *Tiki 26.0 is released and runs under php8.1 to php8.2, but the resources.sources.main in manisfest.toml is not yet update to support the installation of or upgrade to tiki-26.0

## Solution

- Update the manifest.toml main resources.sources and resources.apt packages versions

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
