### PR TITLE
Update app main and lts resources sources to respectively tiki-26.2 and 24.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Tiki Wiki CMS Groupware is the Free / Libre / Open Source Web Application with t
 - Tiki Trackers is the built-in database web apps builder and low-code / no-code application framework.
 
 
-**Shipped version:** 26.1~ynh1
+**Shipped version:** 26.2~ynh1
 
 **Demo:** https://tiki.org/Try-Tiki
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -33,7 +33,7 @@ Tiki Wiki CMS Groupware est l'application Web libre dotée du plus grand nombre 
 Les Tiki Trackers sont la composante intégrée pour le développement low-code / no-code et le générateur de formulaires et bases de données.
 
 
-**Version incluse :** 26.1~ynh1
+**Version incluse :** 26.2~ynh1
 
 **Démo :** https://tiki.org/Try-Tiki
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Tiki"
 description.en = "Wiki-based, content management system"
 description.fr = "Système de gestion de contenu basé sur Wiki"
 
-version = "26.1~ynh1"
+version = "26.2~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -52,13 +52,13 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_26.x_Alnilam/26.1/tiki-26.1.tar.gz/download"
-        sha256 = "f6d0042567feb62bfaf012cb999625ef840501141249a247b3075094030649c7"
+        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_26.x_Alnilam/26.2/tiki-26.2.tar.gz/download"
+        sha256 = "d85d513313e2377ecc2fe03f471b053727cb7f9a40143192f95191891557dabf"
         format = "tar.gz"
 
         [resources.sources.lts]
-        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_24.x_Wolf_359/24.5/tiki-24.5.tar.gz/download"
-        sha256 = "d91cb7846a0c863ab5b1d29a305acd865365364e05f5d83c00e11cae4d67a71b"
+        url = "https://sourceforge.net/projects/tikiwiki/files/Tiki_24.x_Wolf_359/24.6/tiki-24.6.tar.gz/download"
+        sha256 = "1dc1a3f0236c79287b14bfe45eb789e8b0e5c89d2a9089bab496c61a2c73a9f0"
         format = "tar.gz"
 
     [resources.system_user]


### PR DESCRIPTION
## Problem

- New tiki regular and LTS releases available

## Solution

- Update the manifest.toml resources.sources.main and resources.sources to tiki-26.2 and 24.6

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
